### PR TITLE
[PET-to-MLIR] ternaryop for gt condition,floats

### DIFF
--- a/mlir/tools/mlir-pet/Lib/mlirCodegen.h
+++ b/mlir/tools/mlir-pet/Lib/mlirCodegen.h
@@ -16,7 +16,7 @@
 
 namespace codegen {
 
-enum class BinaryOpType { ADD, MUL, SUB, DIV };
+enum class BinaryOpType { ADD, MUL, SUB, DIV, GT };
 
 class SymbolTable {
 public:
@@ -194,6 +194,10 @@ private:
   // create a binary operation.
   mlir::Value createBinaryOp(mlir::Location &loc, mlir::Value &lhs,
                              mlir::Value &rhs, BinaryOpType type);
+
+  // create a ternary operation.
+  mlir::Value createTernaryOp(mlir::Location &loc, mlir::Value &cond,
+                              mlir::Value &rhs, mlir::Value &rhs2);
 
   // create a constant operation.
   mlir::Value createConstantOp(__isl_take pet_expr *expr,

--- a/mlir/tools/mlir-pet/Test/Inputs/ternary.c
+++ b/mlir/tools/mlir-pet/Test/Inputs/ternary.c
@@ -1,0 +1,13 @@
+float aboveZero;
+float belowZero;
+float x;
+
+int foo() {
+#pragma scop
+
+  float x = 1.0f;
+  float mulfactor = x > 0 ? aboveZero : belowZero;
+
+#pragma endscop
+  return 0;
+}

--- a/mlir/tools/mlir-pet/Test/syrk.mlir
+++ b/mlir/tools/mlir-pet/Test/syrk.mlir
@@ -1,35 +1,35 @@
 // RUN: mlir-pet %S/Inputs/syrk.c | FileCheck %s
-// CHECK: #map0 = affine_map<(d0) -> (d0)>
-// CHECK: #map1 = affine_map<(d0, d1) -> (d0, d1)>
-// CHECK: #map2 = affine_map<() -> (0)>
-// CHECK: #map3 = affine_map<(d0) -> (d0 + 1)>
-// CHECK: #map4 = affine_map<() -> (1200)>
-// CHECK: #map5 = affine_map<() -> (2000)>
+// CHECK:#map0 = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK:#map1 = affine_map<(d0) -> (d0)>
+// CHECK:#map2 = affine_map<() -> (0)>
+// CHECK:#map3 = affine_map<(d0) -> (d0 + 1)>
+// CHECK:#map4 = affine_map<() -> (1200)>
+// CHECK:#map5 = affine_map<() -> (2000)>
 
-// CHECK: module {
+// CHECK:module {
 // CHECK:  func @scop_entry(%arg0: memref<2000x1200xf32>, %arg1: memref<2000x2000xf32>, %arg2: memref<1xf32>, %arg3: memref<1xf32>) {
 // CHECK:    affine.for %arg4 = 0 to 2000 {
 // CHECK:      affine.for %arg5 = 0 to #map3(%arg4) {
+// CHECK:        %0 = affine.load %arg1[%arg4, %arg5] : memref<2000x2000xf32>
 // CHECK:        %c0 = constant 0 : index
-// CHECK:        %0 = affine.load %arg3[%c0] : memref<1xf32>
-// CHECK:        %1 = affine.load %arg1[%arg4, %arg5] : memref<2000x2000xf32>
-// CHECK:        %2 = mulf %0, %1 : f32
+// CHECK:        %1 = affine.load %arg3[%c0] : memref<1xf32>
+// CHECK:        %2 = mulf %1, %0 : f32
 // CHECK:        affine.store %2, %arg1[%arg4, %arg5] : memref<2000x2000xf32>
 // CHECK:      }
 // CHECK:      affine.for %arg5 = 0 to 1200 {
 // CHECK:        affine.for %arg6 = 0 to #map3(%arg4) {
+// CHECK:          %0 = affine.load %arg1[%arg4, %arg6] : memref<2000x2000xf32>
 // CHECK:          %c0 = constant 0 : index
-// CHECK:          %0 = affine.load %arg2[%c0] : memref<1xf32>
-// CHECK:          %1 = affine.load %arg0[%arg4, %arg5] : memref<2000x1200xf32>
-// CHECK:          %2 = mulf %0, %1 : f32
-// CHECK:          %3 = affine.load %arg0[%arg6, %arg5] : memref<2000x1200xf32>
-// CHECK:          %4 = mulf %2, %3 : f32
-// CHECK:          %5 = affine.load %arg1[%arg4, %arg6] : memref<2000x2000xf32>
-// CHECK:          %6 = addf %4, %5 : f32
+// CHECK:          %1 = affine.load %arg2[%c0] : memref<1xf32>
+// CHECK:          %2 = affine.load %arg0[%arg4, %arg5] : memref<2000x1200xf32>
+// CHECK:          %3 = mulf %1, %2 : f32
+// CHECK:          %4 = affine.load %arg0[%arg6, %arg5] : memref<2000x1200xf32>
+// CHECK:          %5 = mulf %3, %4 : f32
+// CHECK:          %6 = addf %5, %0 : f32
 // CHECK:          affine.store %6, %arg1[%arg4, %arg6] : memref<2000x2000xf32>
 // CHECK:        }
 // CHECK:      }
 // CHECK:    }
 // CHECK:    return
 // CHECK:  }
-// CHECK: }
+// CHECK:}

--- a/mlir/tools/mlir-pet/Test/ternary.mlir
+++ b/mlir/tools/mlir-pet/Test/ternary.mlir
@@ -1,0 +1,23 @@
+// RUN: mlir-pet %S/Inputs/ternary.c | FileCheck %s
+
+CHECK:  func @scop_entry(%arg0: memref<1xf32>, %arg1: memref<1xf32>) {
+CHECK:    %0 = alloc() : memref<1xf32>
+CHECK:    %cst = constant 1.000000e+00 : f32
+CHECK:    %c0 = constant 0 : index
+CHECK:    affine.store %cst, %0[%c0] : memref<1xf32>
+CHECK:    %1 = alloc() : memref<1xf32>
+CHECK:    %c0_0 = constant 0 : index
+CHECK:    %2 = affine.load %0[%c0_0] : memref<1xf32>
+CHECK:    %cst_1 = constant 0.000000e+00 : f32
+CHECK:    %3 = cmpf "ogt", %2, %cst_1 : f32
+CHECK:    %c0_2 = constant 0 : index
+CHECK:    %4 = affine.load %arg0[%c0_2] : memref<1xf32>
+CHECK:    %c0_3 = constant 0 : index
+CHECK:    %5 = affine.load %arg1[%c0_3] : memref<1xf32>
+CHECK:    %6 = select %3, %4, %5 : f32
+CHECK:    %c0_4 = constant 0 : index
+CHECK:    affine.store %6, %1[%c0_4] : memref<1xf32>
+CHECK:    return
+CHECK:  }
+
+

--- a/mlir/tools/mlir-pet/Test/trisolv.mlir
+++ b/mlir/tools/mlir-pet/Test/trisolv.mlir
@@ -1,25 +1,27 @@
 // RUN: mlir-pet %S/Inputs/trisolv.c | FileCheck %s
-// CHECK: #map0 = affine_map<(d0) -> (d0)>
-// CHECK: #map1 = affine_map<(d0, d1) -> (d0, d1)>
-// CHECK: #map2 = affine_map<() -> (0)>
-// CHECK: #map3 = affine_map<() -> (2000)>
-// CHECK: module {
-// CHECK:   func @scop_entry(%arg0: memref<2000x2000xf32>, %arg1: memref<2000xf32>, %arg2: memref<2000xf32>) {
-// CHECK:     affine.for %arg3 = 0 to 2000 {
-// CHECK:       %0 = affine.load %arg1[%arg3] : memref<2000xf32>
-// CHECK:       affine.store %0, %arg2[%arg3] : memref<2000xf32>
-// CHECK:       affine.for %arg4 = 0 to #map0(%arg3) {
-// CHECK:         %4 = affine.load %arg0[%arg3, %arg4] : memref<2000x2000xf32>
-// CHECK:         %5 = affine.load %arg2[%arg4] : memref<2000xf32>
-// CHECK:         %6 = mulf %4, %5 : f32
-// CHECK:         %7 = affine.load %arg2[%arg3] : memref<2000xf32>
-// CHECK:         %8 = subf %7, %6 : f32
-// CHECK:         affine.store %8, %arg2[%arg3] : memref<2000xf32>
-// CHECK:       }
-// CHECK:       %1 = affine.load %arg0[%arg3, %arg3] : memref<2000x2000xf32>
-// CHECK:       %2 = affine.load %arg2[%arg3] : memref<2000xf32>
-// CHECK:       %3 = divf %2, %1 : f32
-// CHECK:       affine.store %3, %arg2[%arg3] : memref<2000xf32>
-// CHECK:     }
-// CHECK:     return
-// CHECK:   }
+// CHECK:#map0 = affine_map<(d0) -> (d0)>
+// CHECK:#map1 = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK:#map2 = affine_map<() -> (0)>
+// CHECK:#map3 = affine_map<() -> (2000)>
+
+// CHECK:module {
+// CHECK:  func @scop_entry(%arg0: memref<2000x2000xf32>, %arg1: memref<2000xf32>, %arg2: memref<2000xf32>) {
+// CHECK:    affine.for %arg3 = 0 to 2000 {
+// CHECK:      %0 = affine.load %arg1[%arg3] : memref<2000xf32>
+// CHECK:      affine.store %0, %arg2[%arg3] : memref<2000xf32>
+// CHECK:      affine.for %arg4 = 0 to #map0(%arg3) {
+// CHECK:        %4 = affine.load %arg2[%arg3] : memref<2000xf32>
+// CHECK:        %5 = affine.load %arg0[%arg3, %arg4] : memref<2000x2000xf32>
+// CHECK:        %6 = affine.load %arg2[%arg4] : memref<2000xf32>
+// CHECK:        %7 = mulf %5, %6 : f32
+// CHECK:        %8 = subf %4, %7 : f32
+// CHECK:        affine.store %8, %arg2[%arg3] : memref<2000xf32>
+// CHECK:      }
+// CHECK:      %1 = affine.load %arg2[%arg3] : memref<2000xf32>
+// CHECK:      %2 = affine.load %arg0[%arg3, %arg3] : memref<2000x2000xf32>
+// CHECK:      %3 = divf %1, %2 : f32
+// CHECK:      affine.store %3, %arg2[%arg3] : memref<2000xf32>
+// CHECK:    }
+// CHECK:    return
+// CHECK:  }
+// CHECK:}


### PR DESCRIPTION
havent done any correctness checks
would need to add another binary conditions- now its only gt
assumption: pet_op_cond only appears for ternaryOp within isl AST as op; other types of control flow  would appear as IF-nodes in the isl AST.